### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,9 @@ name: Java CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/fxbin/bubble/security/code-scanning/1](https://github.com/fxbin/bubble/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since this workflow only checks out code and builds it using Maven, it does not require any write permissions. The minimal permissions required are `contents: read`. This block should be added at the root level of the workflow file to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
