### PR TITLE
build(bubble-dependencies): 升级 Spring Boot 和 Spring Cloud 版本

### DIFF
--- a/bubble-dependencies/pom.xml
+++ b/bubble-dependencies/pom.xml
@@ -15,12 +15,12 @@
 
     <properties>
         <!-- Spring Boot And Spring Cloud Dependency Versions -->
-        <spring-boot.version>3.4.5</spring-boot.version>
+        <spring-boot.version>3.5.0</spring-boot.version>
         <spring-ai.version>1.0.0</spring-ai.version>
         <spring-modulith.version>1.0.0</spring-modulith.version>
-        <spring-cloud.version>2024.0.1</spring-cloud.version>
+        <spring-cloud.version>2025.0.0</spring-cloud.version>
         <spring-cloud-alibaba.version>2023.0.3.2</spring-cloud-alibaba.version>
-        <spring-boot-admin.version>3.4.5</spring-boot-admin.version>
+        <spring-boot-admin.version>3.5.0</spring-boot-admin.version>
 
         <!-- Other Dependency Versions -->
         <springdoc.version>2.8.6</springdoc.version>


### PR DESCRIPTION
- 将 Spring Boot 版本从3.4.5 升级到3.5.0
- 将 Spring Cloud 版本从2024.0.1 升级到2025.0.0
- 同步更新 Spring Boot Admin 版本到3.5.0